### PR TITLE
Попытка фикса crash-а Fragment.instantiate

### DIFF
--- a/framework/core/platformwrapper/android/proguard/proguard-rules_debug.pro
+++ b/framework/core/platformwrapper/android/proguard/proguard-rules_debug.pro
@@ -45,3 +45,7 @@
 # AndroidX Startup
 -keep class androidx.startup.** { *; }
 -keep class * extends androidx.startup.Initializer { *; }
+
+# AndroidX Lifecycle ReportFragment — prevent R8 obfuscation
+# to fix ClassCastException on process death restoration in AdActivity
+-keep class androidx.lifecycle.ReportFragment { *; }

--- a/framework/core/platformwrapper/android/proguard/proguard-rules_release.pro
+++ b/framework/core/platformwrapper/android/proguard/proguard-rules_release.pro
@@ -46,6 +46,10 @@
 -keep class androidx.startup.** { *; }
 -keep class * extends androidx.startup.Initializer { *; }
 
+# AndroidX Lifecycle ReportFragment — prevent R8 obfuscation
+# to fix ClassCastException on process death restoration in AdActivity
+-keep class androidx.lifecycle.ReportFragment { *; }
+
 -assumenosideeffects class android.util.Log {
 public static boolean isLoggable(...);
 public static int d(...);


### PR DESCRIPTION
Crash: `ReportFragment ClassCastException` (Issue 704506a7)

**Версия:** 831-googlePlay  
**Устройство:** Android 10 (API 29)  
**Количество сессий:** 1  
**Дата:** 03 апреля 2026  

### Стек-трейс

```
Fatal Exception: java.lang.RuntimeException: Unable to start activity
  ComponentInfo{org.popapp.jc/com.google.android.gms.ads.AdActivity}:
  android.app.Fragment$InstantiationException:
  Trying to instantiate a class androidx.lifecycle.m0 that is not a Fragment

Caused by: java.lang.ClassCastException
   at android.app.Fragment.instantiate(Fragment.java:538)
   at android.app.FragmentManagerImpl.restoreAllState(FragmentManager.java:2867)
   at android.app.Activity.onCreate(Activity.java:1501)
   at com.google.android.gms.ads.AdActivity.onCreate
```

### Причина

1. **AndroidX Lifecycle** внедряет `ReportFragment` (extends `android.app.Fragment`) в каждую Activity
2. **R8 (minifyEnabled = true)** обфусцирует `androidx.lifecycle.ReportFragment` → `androidx.lifecycle.m0`
3. Пользователь открывает рекламу → `AdActivity`, lifecycle добавляет `ReportFragment`
4. Происходит **process death** (система убивает процесс в фоне)
5. При восстановлении `FragmentManager.restoreAllState()` пытается инстанцировать фрагмент по обфусцированному имени `m0`
6. `Fragment.instantiate()` не может привести класс к `android.app.Fragment` → **ClassCastException**

В ProGuard-правилах не было keep-правила для `ReportFragment` / наследников `android.app.Fragment`.

### Фикс

Добавлено правило в `proguard-rules_release.pro` и `proguard-rules_debug.pro`:
```
# AndroidX Lifecycle ReportFragment — prevent R8 obfuscation
# to fix ClassCastException on process death restoration in AdActivity
-keep class androidx.lifecycle.ReportFragment { *; }
```
